### PR TITLE
Use save integer conversion for edition number

### DIFF
--- a/jonix/src/main/java/com/tectonica/jonix/unify/base/onix2/BaseDescription2.java
+++ b/jonix/src/main/java/com/tectonica/jonix/unify/base/onix2/BaseDescription2.java
@@ -38,7 +38,7 @@ public class BaseDescription2 extends BaseDescription {
 
     public static void extract(Product product, BaseDescription dest) {
         dest.editionType = product.editionTypeCodes().firstValue().orElse(null);
-        dest.editionNumber = JPU.convertStringToInteger(product.editionNumber().value);
+        dest.editionNumber = JPU.convertStringToIntegerSafe(product.editionNumber().value);
         dest.productForm = product.productForm().value().map(fv -> fv.description).orElse(null);
         dest.numberOfPages = product.numberOfPages().value;
         dest.languages = product.languages().asStructs(); // TODO: lazify


### PR DESCRIPTION
The catalog of Libri (a big book fulfillment company in germany) contains elements with somthing like "XXXX."(i.E. "1404.") as edition number.
Since there can always be some invalid numbers in the data you could use the safe conversion method for this value.