### PR TITLE
Return empty optional if value is null

### DIFF
--- a/jonix-common/src/main/java/com/tectonica/jonix/common/ListOfOnixElement.java
+++ b/jonix-common/src/main/java/com/tectonica/jonix/common/ListOfOnixElement.java
@@ -65,7 +65,7 @@ public class ListOfOnixElement<E extends OnixElement<V>, V> extends ArrayList<E>
      * @return an {@link Optional} of the {@code value} in the first {@link OnixElement} listed, if any
      */
     public Optional<V> firstValue() {
-        return (size() == 0) ? Optional.empty() : Optional.of(get(0).__v());
+        return (size() == 0) || get(0).__v() == null ? Optional.empty() : Optional.of(get(0).__v());
     }
 
     /**


### PR DESCRIPTION
If we return an optional and the first element of the list exists but the value is null the optional throws an exception like:
```
java.lang.NullPointerException: null
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at java.base/java.util.Optional.of(Optional.java:113)
```

So we should return an empty optional if the first element of the list exists but the value is null.